### PR TITLE
Formally require libopenblas, tests added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 sudo: false
+
 addons:
   apt:
     packages:
       - libopenblas-dev
-      - libopenblas-base
-dist: trusty
+
 php:
   - 7.0
   - 7.1
@@ -13,17 +13,21 @@ php:
   - nightly
 
 cache:
-    apt: true
-    ccache: true
-
+  apt: true
+  ccache: true
 
 before_script:
-    - ccache --version
-    - ccache --zero-stats
-    - export USE_CCACHE=1
+  - ccache --version
+  - ccache --zero-stats
+  - export USE_CCACHE=1
+  - phpize
+  - ./configure
+  - make
+  - make install
+  - echo "extension=phpsci.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 script:
-    - ./travis/compile.sh
+  - REPORT_EXIT_STATUS=1 php ./run-tests.php -P -q --show-diff
 
 after_success:
-    - ccache --show-stats
+  - ccache --show-stats

--- a/README.MD
+++ b/README.MD
@@ -27,7 +27,6 @@ Clone the repository, `cd` to the source folder and:
 ```commandline
 $ phpize
 $ ./configure
-$ make CFLAGS=-lopenblas
 $ make test
 $ make install
 ```

--- a/config.m4
+++ b/config.m4
@@ -16,6 +16,8 @@ PHP_CHECK_LIBRARY(openblas,cblas_sdot,
   -lopenblas
 ])
 
+CFLAGS="$CFLAGS -lopenblas"
+
 PHP_NEW_EXTENSION(phpsci,
 	  phpsci.c \
 	  kernel/carray.c \

--- a/config.m4
+++ b/config.m4
@@ -7,6 +7,15 @@ if test "$PHP_PHPSCI" != "no"; then
 
 PHP_ADD_INCLUDE(/opt/OpenBLAS/include/)
 
+PHP_CHECK_LIBRARY(openblas,cblas_sdot,
+[
+  PHP_ADD_LIBRARY(openblas)
+],[
+  AC_MSG_ERROR([wrong openblas version or library not found])
+],[
+  -lopenblas
+])
+
 PHP_NEW_EXTENSION(phpsci,
 	  phpsci.c \
 	  kernel/carray.c \

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,7 @@ Clone the repository, `cd` to the source folder and:
 ```commandline
 $ phpize
 $ ./configure
-$ make CFLAGS=-lopenblas
-$ make
+$ make test
 $ make install
 ```
 > Don't forget to check if the extension is enabled in your php.ini file.

--- a/tests/fromArray_basic.phpt
+++ b/tests/fromArray_basic.phpt
@@ -1,0 +1,23 @@
+--TEST--
+basic test for CArray::fromArray()
+--FILE--
+<?php
+$a = CArray::fromArray([[0, 1], [2, 3]]);
+print_r(CArray::toArray($a->uuid, 2, 2));
+?>
+--EXPECT--
+Array
+(
+    [0] => Array
+        (
+            [0] => 0
+            [1] => 1
+        )
+
+    [1] => Array
+        (
+            [0] => 2
+            [1] => 3
+        )
+
+)

--- a/tests/identity_basic.phpt
+++ b/tests/identity_basic.phpt
@@ -1,0 +1,23 @@
+--TEST--
+basic test for CArray::identity()
+--FILE--
+<?php
+$a = CArray::identity(2);
+$b = CArray::identity(4);
+print_r($a);
+print_r($b);
+?>
+--EXPECT--
+CArray Object
+(
+    [uuid] => 0
+    [x] => 2
+    [y] => 2
+)
+CArray Object
+(
+    [uuid] => 1
+    [x] => 4
+    [y] => 4
+)
+

--- a/tests/toArray_basic.phpt
+++ b/tests/toArray_basic.phpt
@@ -1,0 +1,44 @@
+--TEST--
+basic test for CArray::toArray()
+--FILE--
+<?php
+$a = CArray::identity(4);
+$php_array = CArray::toArray($a->uuid, 4, 4);
+print_r($php_array);
+?>
+--EXPECT--
+Array
+(
+    [0] => Array
+        (
+            [0] => 1
+            [1] => 0
+            [2] => 0
+            [3] => 0
+        )
+
+    [1] => Array
+        (
+            [0] => 0
+            [1] => 1
+            [2] => 0
+            [3] => 0
+        )
+
+    [2] => Array
+        (
+            [0] => 0
+            [1] => 0
+            [2] => 1
+            [3] => 0
+        )
+
+    [3] => Array
+        (
+            [0] => 0
+            [1] => 0
+            [2] => 0
+            [3] => 1
+        )
+
+)

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+set -e
 
 phpize
 ./configure
 make clean
-make
-make install
+make test

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -3,5 +3,5 @@
 phpize
 ./configure
 make clean
-make CFLAGS=-lopenblas
+make
 make install

--- a/travis/compile.sh
+++ b/travis/compile.sh
@@ -4,4 +4,5 @@ set -e
 phpize
 ./configure
 make clean
-make test
+make
+make install


### PR DESCRIPTION
If there's no libopenblas-dev, the build will fail with a missing header file:

```
carray/linalg.c:23:10: fatal error: cblas.h: No such file or directory
 #include "cblas.h"
          ^~~~~~~~~
compilation terminated.
make: *** [Makefile:204: carray/linalg.lo] Error 1
```

We should check for this library from before the actual build. 

With this PR if there's no libopenblas, `./configure` will fail with:
```
checking for cblas_sdot in -lopenblas... no
configure: error: wrong openblas version or library not found
```
Else everything works as usual.

Also, there should be no need to mention `CFLAGS=-lopenblas` anywhere in the docs.

