### PR TITLE
Use PHP-safe memory allocation (emalloc, efree), __destruct

### DIFF
--- a/kernel/carray.c
+++ b/kernel/carray.c
@@ -92,7 +92,7 @@ void carray_init(int rows, int cols, MemoryPointer * ptr)
 {
     CArray x;
     int j, i;
-    x.array2d = (float*)malloc(rows * cols * sizeof(float));
+    x.array2d = (float*)emalloc(rows * cols * sizeof(float));
     x.array1d = NULL;
     x.array0d = NULL;
     add_to_stack(ptr, x,(rows * cols * sizeof(float)));
@@ -112,7 +112,7 @@ void carray_init1d(int width, MemoryPointer * ptr)
     int j, i;
     x.array0d = NULL;
     x.array2d = NULL;
-    x.array1d = (float*)malloc(width * sizeof(float) + 64);
+    x.array1d = (float*)emalloc(width * sizeof(float) + 64);
     add_to_stack(ptr, x,(width * sizeof(float)) + 64);
 }
 
@@ -129,7 +129,7 @@ void carray_init0d(MemoryPointer * ptr)
     int j, i;
     x.array1d = NULL;
     x.array2d = NULL;
-    x.array0d = (float*)malloc(sizeof(float) + 64);
+    x.array0d = (float*)emalloc(sizeof(float) + 64);
     add_to_stack(ptr, x,sizeof(float) + 64);
 }
 
@@ -167,7 +167,7 @@ CArray ptr_to_carray(MemoryPointer * ptr)
  */
 void destroy_carray(MemoryPointer * target_ptr)
 {
-    free(PHPSCI_MAIN_MEM_STACK.buffer[target_ptr->uuid].array2d);
+    efree(PHPSCI_MAIN_MEM_STACK.buffer[target_ptr->uuid].array2d);
     PHPSCI_MAIN_MEM_STACK.size--;
     PHPSCI_MAIN_MEM_STACK.last_deleted_uuid = target_ptr->uuid;
 }

--- a/kernel/memory_manager.c
+++ b/kernel/memory_manager.c
@@ -44,9 +44,7 @@ void stack_init(size_t size) {
     PHPSCI_MAIN_MEM_STACK.last_deleted_uuid = UNINITIALIZED;
     PHPSCI_MAIN_MEM_STACK.bsize = size;
     // Allocate first CArray struct to buffer
-    if((PHPSCI_MAIN_MEM_STACK.buffer = (struct CArray*)emalloc(2 * sizeof(struct CArray))) == NULL){
-        php_printf("[MEMORY STACK] MALLOC FAILED\n");
-    }
+    PHPSCI_MAIN_MEM_STACK.buffer = (struct CArray*)emalloc(2 * sizeof(struct CArray));
 }
 
 /**
@@ -59,10 +57,7 @@ void stack_init(size_t size) {
  */
 void buffer_to_capacity(int new_capacity, size_t size) {
     PHPSCI_MAIN_MEM_STACK.bsize += size;
-    if((PHPSCI_MAIN_MEM_STACK.buffer = (struct CArray*)erealloc(PHPSCI_MAIN_MEM_STACK.buffer, (new_capacity * sizeof(CArray) + sizeof(CArray))))==NULL) {
-        php_printf("[MEMORY STACK] REALLOC FAILED\n");
-    }
-
+    PHPSCI_MAIN_MEM_STACK.buffer = (struct CArray*)erealloc(PHPSCI_MAIN_MEM_STACK.buffer, (new_capacity * sizeof(CArray) + sizeof(CArray)));
     // Set new capacity to MemoryStack
     PHPSCI_MAIN_MEM_STACK.capacity = new_capacity;
 }

--- a/kernel/memory_manager.c
+++ b/kernel/memory_manager.c
@@ -44,7 +44,7 @@ void stack_init(size_t size) {
     PHPSCI_MAIN_MEM_STACK.last_deleted_uuid = UNINITIALIZED;
     PHPSCI_MAIN_MEM_STACK.bsize = size;
     // Allocate first CArray struct to buffer
-    if((PHPSCI_MAIN_MEM_STACK.buffer = (struct CArray*)malloc(2 * sizeof(struct CArray))) == NULL){
+    if((PHPSCI_MAIN_MEM_STACK.buffer = (struct CArray*)emalloc(2 * sizeof(struct CArray))) == NULL){
         php_printf("[MEMORY STACK] MALLOC FAILED\n");
     }
 }
@@ -59,7 +59,7 @@ void stack_init(size_t size) {
  */
 void buffer_to_capacity(int new_capacity, size_t size) {
     PHPSCI_MAIN_MEM_STACK.bsize += size;
-    if((PHPSCI_MAIN_MEM_STACK.buffer = (struct CArray*)realloc(PHPSCI_MAIN_MEM_STACK.buffer, (new_capacity * sizeof(CArray) + sizeof(CArray))))==NULL) {
+    if((PHPSCI_MAIN_MEM_STACK.buffer = (struct CArray*)erealloc(PHPSCI_MAIN_MEM_STACK.buffer, (new_capacity * sizeof(CArray) + sizeof(CArray))))==NULL) {
         php_printf("[MEMORY STACK] REALLOC FAILED\n");
     }
 

--- a/phpsci.c
+++ b/phpsci.c
@@ -139,12 +139,9 @@ PHP_METHOD(CArray, fromArray)
     array_to_carray_ptr(&ptr, array, &a_rows, &a_cols);
     RETURN_CARRAY(return_value, ptr.uuid, a_rows, a_cols);
 }
-PHP_METHOD(CArray, destroy)
+PHP_METHOD(CArray, __destruct)
 {
-    zval * obj;
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_OBJECT(obj)
-    ZEND_PARSE_PARAMETERS_END();
+    zval * obj = getThis();
     MemoryPointer target_ptr;
     OBJ_TO_PTR(obj, &target_ptr);
     destroy_carray(&target_ptr);
@@ -354,8 +351,8 @@ static zend_function_entry phpsci_class_methods[] =
    PHP_ME(CArray, inv, NULL, ZEND_ACC_STATIC | ZEND_ACC_PUBLIC)
    
    // CARRAY MEMORY MANAGEMENT SECTION
-   PHP_ME(CArray, destroy, NULL, ZEND_ACC_STATIC | ZEND_ACC_PUBLIC)
-   
+   PHP_ME(CArray, __destruct, NULL, ZEND_ACC_PUBLIC)
+
    // INITIALIZERS SECTION
    PHP_ME(CArray, identity, NULL, ZEND_ACC_STATIC | ZEND_ACC_PUBLIC)
    PHP_ME(CArray, zeros, NULL, ZEND_ACC_STATIC | ZEND_ACC_PUBLIC)

--- a/tests/destroy_basic.phpt
+++ b/tests/destroy_basic.phpt
@@ -1,19 +1,18 @@
 --TEST--
-basic test for CArray::destroy()
+basic test for CArray::__destruct()
 --FILE--
 <?php
-$a = CArray::fromArray([[100,1],[2,3]]);
-var_dump($a->uuid);
-CArray::destroy($a);
-var_dump($a->uuid);
+function create_scoped()
+{
+    $before = memory_get_usage(true);
+    $a = CArray::identity(1024);
+    var_dump(memory_get_usage(true) - $before == 1 << 22);
+}
 
-$b = CArray::fromArray([[200,1],[2,3]]);
-var_dump($b->uuid);
-CArray::destroy($b);
-var_dump($b->uuid);
-?>
+$before = memory_get_usage(true);
+create_scoped();
+gc_collect_cycles();
+var_dump(memory_get_usage(true) == $before);
 --EXPECT--
-int(0)
-int(0)
-int(0)
-int(0)
+bool(true)
+bool(true)

--- a/tests/destroy_useafterfree.phpt
+++ b/tests/destroy_useafterfree.phpt
@@ -1,9 +1,0 @@
---TEST--
-Use-after-free bug demo for CArray::destroy()
---FILE--
-<?php
-$a = CArray::fromArray([[0,1],[2,3]]);
-CArray::destroy($a);
-// should print nothing here
-?>
---EXPECT--


### PR DESCRIPTION
* Switch to use PHP-safe memory allocation; [apparently this](http://php.net/manual/en/internals2.memory.management.php) is what you have to use for PHP; [what Rasmus says](https://marc.info/?l=php-internals&m=103334006314248). This way phpsci-ext respects memory limits set by PHP.
* Since our memory is managed by PHP, we can use automatic destruction.
* Since there's no `destruct()`, we're one use-after-free bug less.



