### PR TITLE
CArray Architecture improvements and updates

### DIFF
--- a/carray/arithmetic.c
+++ b/carray/arithmetic.c
@@ -157,7 +157,7 @@ void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
 {
     int i, j;
     if(GET_DIM(x_b, y_b) == 0) {
-        carray_init(x_a, y_a, rtn_ptr);
+        carray_init2d(x_a, y_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
         *size_x = x_a;
         *size_y = y_a;
@@ -169,7 +169,7 @@ void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
         return;
     }
     if(GET_DIM(x_b, y_b) == 1) {
-        carray_init(x_a, y_a, rtn_ptr);
+        carray_init2d(x_a, y_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
         *size_x = x_a;
         *size_y = y_a;
@@ -181,7 +181,7 @@ void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
         return;
     }
     if(x_a == x_b) {
-        carray_init(x_a, y_a, rtn_ptr);
+        carray_init2d(x_a, y_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
         *size_x = x_a;
         *size_y = y_a;
@@ -193,7 +193,7 @@ void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
         return;
     }
     if(x_b < x_a && x_b == 1) {
-        carray_init(x_a, y_a, rtn_ptr);
+        carray_init2d(x_a, y_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
         *size_x = x_a;
         *size_y = y_a;

--- a/carray/arithmetic.c
+++ b/carray/arithmetic.c
@@ -39,44 +39,44 @@
  * @param y_b
  * @param rtn_ptr
  */
-void add(MemoryPointer * ptr_a, int x_a, int y_a, MemoryPointer * ptr_b, int x_b, int y_b, MemoryPointer * rtn_ptr, int * size_x, int * size_y)
+void add(MemoryPointer * ptr_a, MemoryPointer * ptr_b, MemoryPointer * rtn_ptr)
 {
     CArray arr_a = ptr_to_carray(ptr_a);
     CArray arr_b = ptr_to_carray(ptr_b);
-    if(GET_DIM(x_a, y_a) == 0 && GET_DIM(x_b, y_b) == 0) {
-        add_carray_0d(&arr_a, x_a, y_a, &arr_b, x_b, y_b, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 0 && PTR_TO_DIM(ptr_b) == 0) {
+        add_carray_0d(&arr_a, ptr_a->x, ptr_a->y, &arr_b, ptr_b->x, ptr_b->y, rtn_ptr);
         return;
     }
-    if(GET_DIM(x_a, y_a) == 0 && GET_DIM(x_b, y_b) == 1) {
-        add_carray_1d(&arr_b, x_b, y_b, &arr_a, x_a, y_a, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 0 && PTR_TO_DIM(ptr_b) == 1) {
+        add_carray_1d(&arr_b, ptr_b->x, ptr_b->y, &arr_a, ptr_a->x, ptr_a->y, rtn_ptr);
         return;
     }
-    if(GET_DIM(x_a, y_a) == 1 && GET_DIM(x_b, y_b) == 0) {
-        add_carray_1d(&arr_a, x_a, y_a, &arr_b, x_b, y_b, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 1 && PTR_TO_DIM(ptr_b) == 0) {
+        add_carray_1d(&arr_a, ptr_a->x, ptr_a->y, &arr_b, ptr_b->x, ptr_b->y, rtn_ptr);
         return;
     }
-    if(GET_DIM(x_a, y_a) == 1 && GET_DIM(x_b, y_b) == 1) {
-        add_carray_1d(&arr_a, x_a, y_a, &arr_b, x_b, y_b, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 1 && PTR_TO_DIM(ptr_b) == 1) {
+        add_carray_1d(&arr_a, ptr_a->x, ptr_a->y, &arr_b, ptr_b->x, ptr_b->y, rtn_ptr);
         return;
     }
-    if(GET_DIM(x_a, y_a) == 0 && GET_DIM(x_b, y_b) == 2) {
-        add_carray_2d(&arr_b, x_b, y_b, &arr_a, x_a, y_a, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 0 && PTR_TO_DIM(ptr_b) == 2) {
+        add_carray_2d(&arr_b, ptr_b->x, ptr_b->y, &arr_a, ptr_a->x, ptr_a->y, rtn_ptr);
         return;
     }
-    if(GET_DIM(x_a, y_a) == 2 && GET_DIM(x_b, y_b) == 0) {
-        add_carray_2d(&arr_a, x_a, y_a, &arr_b, x_b, y_b, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 2 && PTR_TO_DIM(ptr_b) == 0) {
+        add_carray_2d(&arr_a, ptr_a->x, ptr_a->y, &arr_b, ptr_b->x, ptr_b->y, rtn_ptr);
         return;
     }
-    if(GET_DIM(x_a, y_a) == 1 && GET_DIM(x_b, y_b) == 2) {
-        add_carray_2d(&arr_b, x_b, y_b, &arr_a, x_a, y_a, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 1 && PTR_TO_DIM(ptr_b) == 2) {
+        add_carray_2d(&arr_b, ptr_b->x, ptr_b->y, &arr_a, ptr_a->x, ptr_a->y, rtn_ptr);
         return;
     }
-    if(GET_DIM(x_a, y_a) == 2 && GET_DIM(x_b, y_b) == 1) {
-        add_carray_2d(&arr_a, x_a, y_a, &arr_b, x_b, y_b, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 2 && PTR_TO_DIM(ptr_b) == 1) {
+        add_carray_2d(&arr_a, ptr_a->x, ptr_a->y, &arr_b, ptr_b->x, ptr_b->y, rtn_ptr);
         return;
     }
-    if(GET_DIM(x_a, y_a) == 2 && GET_DIM(x_b, y_b) == 2) {
-        add_carray_2d(&arr_a, x_a, y_a, &arr_b, x_b, y_b, rtn_ptr, size_x, size_y);
+    if(PTR_TO_DIM(ptr_a) == 2 && PTR_TO_DIM(ptr_b) == 2) {
+        add_carray_2d(&arr_a, ptr_a->x, ptr_a->y, &arr_b, ptr_b->x, ptr_b->y, rtn_ptr);
         return;
     }
 }
@@ -93,11 +93,11 @@ void add(MemoryPointer * ptr_a, int x_a, int y_a, MemoryPointer * ptr_b, int x_b
  * @param y_b
  * @param rtn_ptr
  */
-void add_carray_0d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr, int * size_x, int * size_y)
+void add_carray_0d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr)
 {
     int i, j;
-    *size_x = 0;
-    *size_y = 0;
+    rtn_ptr->x = 0;
+    rtn_ptr->y = 0;
     carray_init0d(rtn_ptr);
     CArray rtn_arr = ptr_to_carray(rtn_ptr);
     rtn_arr.array0d[0] = a->array0d[0] + b->array0d[0];
@@ -116,14 +116,14 @@ void add_carray_0d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
  * @param y_b
  * @param rtn_ptr
  */
-void add_carray_1d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr, int * size_x, int * size_y)
+void add_carray_1d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr)
 {
     int i, j;
     if(GET_DIM(x_b, y_b) == 0) {
         carray_init1d(x_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
-        *size_x = x_a;
-        *size_y = 0;
+        rtn_ptr->x = x_a;
+        rtn_ptr->y = 0;
         for(i = 0; i < x_a; ++i) {
             rtn_arr.array1d[i] = a->array1d[i] + b->array0d[0];
         }
@@ -134,8 +134,8 @@ void add_carray_1d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
     for(i = 0; i < x_a; ++i) {
         rtn_arr.array1d[i] = a->array1d[i] + b->array1d[i];
     }
-    *size_x = x_a;
-    *size_y = 0;
+    rtn_ptr->x = x_a;
+    rtn_ptr->y = 0;
     return;
 }
 
@@ -153,14 +153,14 @@ void add_carray_1d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
  * @param size_x
  * @param size_y
  */
-void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr, int * size_x, int * size_y)
+void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr)
 {
     int i, j;
     if(GET_DIM(x_b, y_b) == 0) {
         carray_init2d(x_a, y_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
-        *size_x = x_a;
-        *size_y = y_a;
+        rtn_ptr->x = x_a;
+        rtn_ptr->y = y_a;
         for(i = 0; i < x_a; ++i) {
             for(j = 0; j < y_a; ++j) {
                 rtn_arr.array2d[(j * x_a) + i] = a->array2d[(j * x_a) + i] + b->array0d[0];
@@ -171,8 +171,8 @@ void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
     if(GET_DIM(x_b, y_b) == 1) {
         carray_init2d(x_a, y_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
-        *size_x = x_a;
-        *size_y = y_a;
+        rtn_ptr->x = x_a;
+        rtn_ptr->y = y_a;
         for(i = 0; i < x_a; ++i) {
             for(j = 0; j < y_a; ++j) {
                 rtn_arr.array2d[(j * x_a) + i] = a->array2d[(j * x_a) + i] + b->array1d[j];
@@ -183,8 +183,8 @@ void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
     if(x_a == x_b) {
         carray_init2d(x_a, y_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
-        *size_x = x_a;
-        *size_y = y_a;
+        rtn_ptr->x = x_a;
+        rtn_ptr->y = y_a;
         for(i = 0; i < x_a; ++i) {
             for(j = 0; j < y_a; ++j) {
                 rtn_arr.array2d[(j * x_a) + i] = a->array2d[(j * x_a) + i] + b->array2d[(j * x_a) + i];
@@ -195,8 +195,8 @@ void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, M
     if(x_b < x_a && x_b == 1) {
         carray_init2d(x_a, y_a, rtn_ptr);
         CArray rtn_arr = ptr_to_carray(rtn_ptr);
-        *size_x = x_a;
-        *size_y = y_a;
+        rtn_ptr->x = x_a;
+        rtn_ptr->y = y_a;
         for(i = 0; i < x_a; ++i) {
             for(j = 0; j < y_a; ++j) {
                 rtn_arr.array2d[(j * x_a) + i] = a->array2d[(j * x_a) + i] + b->array2d[(j * x_b) + 0];

--- a/carray/arithmetic.h
+++ b/carray/arithmetic.h
@@ -26,9 +26,9 @@
 
 #include "../kernel/memory_manager.h"
 
-void add(MemoryPointer * ptr_a, int x_a, int y_a, MemoryPointer * ptr_b, int x_b, int y_b, MemoryPointer * rtn_ptr, int * size_x, int * size_y);
-void add_carray_0d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr, int * size_x, int * size_y);
-void add_carray_1d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr, int * size_x, int * size_y);
-void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr, int * size_x, int * size_y);
+void add(MemoryPointer * ptr_a, MemoryPointer * ptr_b, MemoryPointer * rtn_ptr);
+void add_carray_0d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr);
+void add_carray_1d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr);
+void add_carray_2d(CArray * a, int x_a, int y_a, CArray * b, int x_b, int y_b, MemoryPointer * rtn_ptr);
 
 #endif //PHPSCI_EXT_ARITHMETIC_H

--- a/carray/linalg.c
+++ b/carray/linalg.c
@@ -43,7 +43,7 @@ void inv(MemoryPointer * target_ptr, MemoryPointer * rtn_ptr)
     lapack_int ret, m, n, lda;
     // Load CArrays
     CArray target_carray = ptr_to_carray(target_ptr);
-    carray_init(target_ptr->x, target_ptr->y, rtn_ptr);
+    carray_init2d(target_ptr->x, target_ptr->y, rtn_ptr);
     CArray rtn_carray = ptr_to_carray(rtn_ptr);
     memcpy(rtn_carray.array2d, target_carray.array2d, (target_ptr->x * target_ptr->y * sizeof(double)));
     // Use LAPACKE to calculate
@@ -98,7 +98,7 @@ void inner(int * rtn_x, int * rtn_y, MemoryPointer * ptr, int x_a, int y_a, Memo
         return;
     }
     if (IS_2D(x_a, y_a) && IS_2D(x_b, y_b)) {
-        carray_init(x_a, x_a, ptr);
+        carray_init2d(x_a, x_a, ptr);
         CArray rtn_arr = ptr_to_carray(ptr);
         for(i = 0; i < x_a; i++) {
             for(j = 0; j < x_a; j++) {
@@ -113,7 +113,7 @@ void inner(int * rtn_x, int * rtn_y, MemoryPointer * ptr, int x_a, int y_a, Memo
         return;
     }
     if (IS_2D(x_a, y_a) && IS_0D(x_b, y_b)) {
-        carray_init(x_a, y_a, ptr);
+        carray_init2d(x_a, y_a, ptr);
         CArray rtn_arr = ptr_to_carray(ptr);
         for(i = 0; i < x_a; i++) {
             for(j = 0; j < y_a; j++) {
@@ -147,7 +147,7 @@ void matmul(MemoryPointer * ptr, int n_a_rows, int n_a_cols, MemoryPointer * a_p
     CArray a = ptr_to_carray(a_ptr);
     CArray b = ptr_to_carray(b_ptr);
     if(n_b_cols > 0 && n_a_cols > 0) {
-        carray_init(n_a_rows, n_b_cols, ptr);
+        carray_init2d(n_a_rows, n_b_cols, ptr);
         CArray rtn = ptr_to_carray(ptr);
         cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, n_a_rows, n_b_cols, n_a_cols, 1.0f, a.array2d, n_a_rows, b.array2d, n_b_rows, 0.0f, rtn.array2d, n_a_rows);
         return;

--- a/carray/random.c
+++ b/carray/random.c
@@ -45,7 +45,7 @@ void standard_normal(MemoryPointer * ptr, int seed, int x, int y)
         }
     }
     if(x > 0 && y > 0) {
-        carray_init(x, y, ptr);
+        carray_init2d(x, y, ptr);
         CArray new_arr = ptr_to_carray(ptr);
         for(i = 0; i < x; i++) {
             for(j = 0; j < y; j++)

--- a/carray/transformations.c
+++ b/carray/transformations.c
@@ -32,7 +32,7 @@
  */
 void transpose(MemoryPointer * new_ptr, MemoryPointer * target_ptr, int rows, int cols) {
     int i, j;
-    carray_init(cols, rows, new_ptr);
+    carray_init2d(cols, rows, new_ptr);
     CArray new_arr = ptr_to_carray(new_ptr);
     CArray target_arr = ptr_to_carray(target_ptr);
     for(i = 0; i < rows; i++) {

--- a/config.m4
+++ b/config.m4
@@ -81,6 +81,7 @@ PHP_NEW_EXTENSION(phpsci,
 	  carray/arithmetic.c \
 	  kernel/carray_printer.c \
 	  kernel/php_array.c \
+	  kernel/shape.c \
 	  carray/transformations.c,
 	  $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_INSTALL_HEADERS([ext/phpsci], [phpsci.h])

--- a/config.m4
+++ b/config.m4
@@ -80,6 +80,7 @@ PHP_NEW_EXTENSION(phpsci,
 	  carray/random.c \
 	  carray/arithmetic.c \
 	  kernel/carray_printer.c \
+	  kernel/php_array.c \
 	  carray/transformations.c,
 	  $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
   PHP_INSTALL_HEADERS([ext/phpsci], [phpsci.h])

--- a/kernel/carray.c
+++ b/kernel/carray.c
@@ -183,55 +183,6 @@ void destroy_carray(MemoryPointer * target_ptr)
 }
 
 /**
- * Create MemoryPointer from ZVAL
- *
- * @author Henrique Borba <henrique.borba.dev@gmail.com>
- * @param arr zval *           PHP Array to convert
- * @param pt MemoryPointer *   MemoryPointer
- */
-void array_to_carray_ptr(MemoryPointer * ptr, zval * array, int * rows, int * cols)
-{
-    zval * row, * col;
-    CArray temp;
-    int i =0, j=0;
-    *rows = zend_hash_num_elements(Z_ARRVAL_P(array));
-    *cols = 0;
-    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(array), row) {
-        ZVAL_DEREF(row);
-        if (Z_TYPE_P(row) == IS_ARRAY) {
-            *cols = zend_hash_num_elements(Z_ARRVAL_P(row));
-            if (ptr->uuid == UNINITIALIZED) {
-                carray_init(*rows, *cols, ptr);
-                temp = ptr_to_carray(ptr);
-            }
-            convert_to_array(row);
-
-        } else  {
-            if (ptr->uuid == UNINITIALIZED) {
-                carray_init1d(*rows, ptr);
-                temp = ptr_to_carray(ptr);
-            }
-        }
-    } ZEND_HASH_FOREACH_END();
-    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(array), row) {
-        ZVAL_DEREF(row);
-        if (Z_TYPE_P(row) == IS_ARRAY) {
-            ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(row), col) {
-                convert_to_double(col);
-                temp.array2d[(j * *rows) + i] = (double)Z_DVAL_P(col);
-                ++j;
-            } ZEND_HASH_FOREACH_END();
-        } else {
-            convert_to_double(row);
-            temp.array1d[i] = (double)Z_DVAL_P(row);
-        }
-        j = 0;
-        ++i;
-    } ZEND_HASH_FOREACH_END();
-}
-
-
-/**
  * Create ZVAL_ARR from CArray
  *
  * @author Henrique Borba <henrique.borba.dev@gmail.com>

--- a/kernel/carray.c
+++ b/kernel/carray.c
@@ -27,6 +27,15 @@
 #include "exceptions.h"
 #include "php.h"
 
+/**
+ * @author Henrique Borba <henrique.borba.dev@gmail.com>
+ *
+ * @return
+ */
+int PTR_TO_DIM(MemoryPointer * ptr)
+{
+    return GET_DIM(ptr->x, ptr->y);
+}
 
 /**
  * Get CArray dimensions based on X and Y
@@ -264,8 +273,8 @@ int validate_carray_arithmetic_broadcast(CArray a, CArray b, int * broadcasted_s
  *
  * @author Henrique Borba <henrique.borba.dev@gmail.com>
  */
-void carray_broadcast_arithmetic(MemoryPointer * a, MemoryPointer * b, MemoryPointer * rtn_ptr, int * rtn_x, int * rtn_y,
-                      void cFunction(MemoryPointer * , int , int , MemoryPointer * , int , int , MemoryPointer * , int * , int * )
+void carray_broadcast_arithmetic(MemoryPointer * a, MemoryPointer * b, MemoryPointer * rtn_ptr,
+                      void cFunction(MemoryPointer * , MemoryPointer * , MemoryPointer *)
 )
 {
     CArray arr_a = ptr_to_carray(a);
@@ -278,11 +287,11 @@ void carray_broadcast_arithmetic(MemoryPointer * a, MemoryPointer * b, MemoryPoi
         return;
     }
     if( validate_rtn == 1 ) {
-        cFunction(a, a->x, a->y, b, b->x, b->y, rtn_ptr, rtn_x, rtn_y);
+        cFunction(a, b, rtn_ptr);
         return;
     }
     if( validate_rtn == 2 ) {
-        cFunction(b, b->x, b->y, a, a->x, a->y, rtn_ptr, rtn_x, rtn_y);
+        cFunction(b, a, rtn_ptr);
         return;
     }
 }

--- a/kernel/carray.h
+++ b/kernel/carray.h
@@ -26,14 +26,6 @@
 #include "../phpsci.h"
 
 /**
- * PHPSci Shape Structure
- */
-typedef struct Shape {
-    int * shape;
-    int * dim;
-} Shape;
-
-/**
  * PHPSci internal array structure
  *
  * Currently working with shaped 2D, 1D and 0D.
@@ -45,7 +37,7 @@ typedef struct CArray {
     double *   array0d;
     // NEW IMPLEMENTATION
     double *   array;
-    Shape  *   array_shape;
+    Shape  array_shape;
 } CArray;
 
 /**
@@ -65,12 +57,13 @@ int IS_2D(int x, int y);
 
 int PTR_TO_DIM(MemoryPointer * ptr);
 void OBJ_TO_PTR(zval * obj, MemoryPointer * ptr);
-void carray_init(Shape shape, MemoryPointer * ptr);
+void carray_init(Shape * init_shape, MemoryPointer * ptr);
 void carray_init2d(int rows, int cols, MemoryPointer * ptr);
 void carray_init1d(int width, MemoryPointer * ptr);
 void carray_init0d(MemoryPointer * ptr);
 void destroy_carray(MemoryPointer * target_ptr);
 
+CArray * ptr_to_carray_ref(MemoryPointer * ptr);
 CArray ptr_to_carray(MemoryPointer * ptr);
 void carray_to_array(CArray carray, zval * rtn_array, int m, int n);
 void double_to_carray(double input, MemoryPointer * rtn_ptr);

--- a/kernel/carray.h
+++ b/kernel/carray.h
@@ -63,6 +63,7 @@ int IS_0D(int x, int y);
 int IS_1D(int x, int y);
 int IS_2D(int x, int y);
 
+int PTR_TO_DIM(MemoryPointer * ptr);
 void OBJ_TO_PTR(zval * obj, MemoryPointer * ptr);
 void carray_init(Shape shape, MemoryPointer * ptr);
 void carray_init2d(int rows, int cols, MemoryPointer * ptr);
@@ -74,8 +75,8 @@ CArray ptr_to_carray(MemoryPointer * ptr);
 void carray_to_array(CArray carray, zval * rtn_array, int m, int n);
 void double_to_carray(double input, MemoryPointer * rtn_ptr);
 
-void carray_broadcast_arithmetic(MemoryPointer * a, MemoryPointer * b, MemoryPointer * rtn_ptr, int * rtn_x, int * rtn_y,
-     void cFunction(MemoryPointer * , int , int , MemoryPointer * , int , int , MemoryPointer * , int * , int * )
+void carray_broadcast_arithmetic(MemoryPointer * a, MemoryPointer * b, MemoryPointer * rtn_ptr,
+     void cFunction(MemoryPointer * , MemoryPointer * , MemoryPointer *)
 );
 
 #endif //PHPSCI_EXT_CARRAY_H

--- a/kernel/carray.h
+++ b/kernel/carray.h
@@ -44,8 +44,8 @@ typedef struct CArray {
     double *   array1d;
     double *   array0d;
     // NEW IMPLEMENTATION
-    double * array;
-    Shape  * shape;
+    double *   array;
+    Shape  *   array_shape;
 } CArray;
 
 /**
@@ -64,7 +64,8 @@ int IS_1D(int x, int y);
 int IS_2D(int x, int y);
 
 void OBJ_TO_PTR(zval * obj, MemoryPointer * ptr);
-void carray_init(int rows, int cols, MemoryPointer * ptr);
+void carray_init(Shape shape, MemoryPointer * ptr);
+void carray_init2d(int rows, int cols, MemoryPointer * ptr);
 void carray_init1d(int width, MemoryPointer * ptr);
 void carray_init0d(MemoryPointer * ptr);
 void destroy_carray(MemoryPointer * target_ptr);
@@ -72,4 +73,9 @@ void destroy_carray(MemoryPointer * target_ptr);
 CArray ptr_to_carray(MemoryPointer * ptr);
 void carray_to_array(CArray carray, zval * rtn_array, int m, int n);
 void double_to_carray(double input, MemoryPointer * rtn_ptr);
+
+void carray_broadcast_arithmetic(MemoryPointer * a, MemoryPointer * b, MemoryPointer * rtn_ptr, int * rtn_x, int * rtn_y,
+     void cFunction(MemoryPointer * , int , int , MemoryPointer * , int , int , MemoryPointer * , int * , int * )
+);
+
 #endif //PHPSCI_EXT_CARRAY_H

--- a/kernel/exceptions.c
+++ b/kernel/exceptions.c
@@ -22,3 +22,36 @@
 */
 
 #include "exceptions.h"
+#include "php_array.h"
+#include "php.h"
+#include "Zend/zend_exceptions.h"
+
+#define COULD_NOT_BROADCAST_EXCEPTION 5000
+
+static zend_class_entry * phpsci_ce_CArrayBroadcastException;
+
+static const zend_function_entry phpsci_ce_CArrayBroadcastException_methods[] = {
+        PHP_FE_END
+};
+
+/**
+ * Initialize Exception Classes
+ *
+ * @author Henrique Borba <henrique.borba.dev@gmail.com>
+ */
+void init_exception_objects()
+{
+    zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "CArrayBroadcastException", phpsci_ce_CArrayBroadcastException_methods);
+    phpsci_ce_CArrayBroadcastException = zend_register_internal_class_ex(&ce, zend_ce_exception);
+}
+
+/**
+ * Throw CArrayBroadcastException
+ *
+ * @author Henrique Borba <henrique.borba.dev@gmail.com>
+ */
+void throw_could_not_broadcast_exception(char * msg)
+{
+    zend_throw_exception_ex(phpsci_ce_CArrayBroadcastException, COULD_NOT_BROADCAST_EXCEPTION, "%s", msg);
+}

--- a/kernel/exceptions.h
+++ b/kernel/exceptions.h
@@ -23,6 +23,7 @@
 
 #ifndef PHPSCI_EXT_EXCEPTIONS_H
 #define PHPSCI_EXT_EXCEPTIONS_H
-
-
+#include "php.h"
+void init_exception_objects();
+void throw_could_not_broadcast_exception(char * msg);
 #endif //PHPSCI_EXT_EXCEPTIONS_H

--- a/kernel/php_array.c
+++ b/kernel/php_array.c
@@ -36,24 +36,26 @@
 void array_to_carray_ptr(MemoryPointer * ptr, zval * array, int * rows, int * cols)
 {
     zval * row, * col;
-    CArray temp;
-    int i =0, j=0;
+    CArray * temp;
+    int i =0, j=0, dim = 0;
+    int iterator;
     *rows = zend_hash_num_elements(Z_ARRVAL_P(array));
     *cols = 0;
+    array_dim(array, &dim);
     ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(array), row) {
         ZVAL_DEREF(row);
         if (Z_TYPE_P(row) == IS_ARRAY) {
             *cols = zend_hash_num_elements(Z_ARRVAL_P(row));
             if (ptr->uuid == UNINITIALIZED) {
                 carray_init2d(*rows, *cols, ptr);
-                temp = ptr_to_carray(ptr);
+                temp = ptr_to_carray_ref(ptr);
             }
             convert_to_array(row);
 
         } else  {
             if (ptr->uuid == UNINITIALIZED) {
                 carray_init1d(*rows, ptr);
-                temp = ptr_to_carray(ptr);
+                temp = ptr_to_carray_ref(ptr);
             }
         }
     } ZEND_HASH_FOREACH_END();
@@ -62,16 +64,19 @@ void array_to_carray_ptr(MemoryPointer * ptr, zval * array, int * rows, int * co
         if (Z_TYPE_P(row) == IS_ARRAY) {
             ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(row), col) {
                 convert_to_double(col);
-                temp.array2d[(j * *rows) + i] = (double)Z_DVAL_P(col);
+                temp->array2d[(j * *rows) + i] = (double)Z_DVAL_P(col);
                 ++j;
             } ZEND_HASH_FOREACH_END();
         } else {
             convert_to_double(row);
-            temp.array1d[i] = (double)Z_DVAL_P(row);
+            temp->array1d[i] = (double)Z_DVAL_P(row);
         }
         j = 0;
         ++i;
     } ZEND_HASH_FOREACH_END();
+    temp->array_shape.dim = dim;
+    temp->array_shape.config = NULL;
+    array_shape(array, &(temp->array_shape), dim, &iterator);
 }
 
 /**
@@ -83,13 +88,35 @@ void array_to_carray_ptr(MemoryPointer * ptr, zval * array, int * rows, int * co
  */
 void array_dim(zval * array, int * dim)
 {
-    if(dim == NULL)
-        *dim = 0;
     zval *entry = NULL;
     if (Z_TYPE_P(array) == IS_ARRAY) {
         *dim = *dim + 1;
         entry = zend_hash_get_current_data(Z_ARRVAL_P(array));
         array_dim(entry, dim);
+    }
+    return;
+}
+
+/**
+ * Get PHP array shape
+ *
+ * @param arr
+ * @param shape
+ */
+void array_shape(zval * arr, Shape * shape, int dim, int * iterator)
+{
+    zval *entry = NULL;
+    // Initialize Shape
+    if(shape->config == NULL) {
+        shape->config = (int *) emalloc(dim * sizeof(int));
+        *iterator = 0;
+    }
+    // Iterate over dimensions
+    if (Z_TYPE_P(arr) == IS_ARRAY) {
+        shape->config[*iterator] = (int)zend_hash_num_elements(Z_ARRVAL_P(arr));
+        entry = zend_hash_get_current_data(Z_ARRVAL_P(arr));
+        *iterator = *iterator + 1;
+        array_shape(entry, shape, dim, iterator);
     }
     return;
 }

--- a/kernel/php_array.c
+++ b/kernel/php_array.c
@@ -45,7 +45,7 @@ void array_to_carray_ptr(MemoryPointer * ptr, zval * array, int * rows, int * co
         if (Z_TYPE_P(row) == IS_ARRAY) {
             *cols = zend_hash_num_elements(Z_ARRVAL_P(row));
             if (ptr->uuid == UNINITIALIZED) {
-                carray_init(*rows, *cols, ptr);
+                carray_init2d(*rows, *cols, ptr);
                 temp = ptr_to_carray(ptr);
             }
             convert_to_array(row);

--- a/kernel/php_array.c
+++ b/kernel/php_array.c
@@ -1,0 +1,95 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHPSci CArray                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2018 PHPSci Team                                       |
+  +----------------------------------------------------------------------+
+  | Licensed under the Apache License, Version 2.0 (the "License");      |
+  | you may not use this file except in compliance with the License.     |
+  | You may obtain a copy of the License at                              |
+  |                                                                      |
+  |     http://www.apache.org/licenses/LICENSE-2.0                       |
+  |                                                                      |
+  | Unless required by applicable law or agreed to in writing, software  |
+  | distributed under the License is distributed on an "AS IS" BASIS,    |
+  | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or      |
+  | implied.                                                             |
+  | See the License for the specific language governing permissions and  |
+  | limitations under the License.                                       |
+  +----------------------------------------------------------------------+
+  | Authors: Henrique Borba <henrique.borba.dev@gmail.com>               |
+  +----------------------------------------------------------------------+
+*/
+
+#include "php_array.h"
+#include "../phpsci.h"
+#include "php.h"
+
+
+/**
+ * Create MemoryPointer from ZVAL
+ *
+ * @author Henrique Borba <henrique.borba.dev@gmail.com>
+ * @param arr zval *           PHP Array to convert
+ * @param pt MemoryPointer *   MemoryPointer
+ */
+void array_to_carray_ptr(MemoryPointer * ptr, zval * array, int * rows, int * cols)
+{
+    zval * row, * col;
+    CArray temp;
+    int i =0, j=0;
+    *rows = zend_hash_num_elements(Z_ARRVAL_P(array));
+    *cols = 0;
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(array), row) {
+        ZVAL_DEREF(row);
+        if (Z_TYPE_P(row) == IS_ARRAY) {
+            *cols = zend_hash_num_elements(Z_ARRVAL_P(row));
+            if (ptr->uuid == UNINITIALIZED) {
+                carray_init(*rows, *cols, ptr);
+                temp = ptr_to_carray(ptr);
+            }
+            convert_to_array(row);
+
+        } else  {
+            if (ptr->uuid == UNINITIALIZED) {
+                carray_init1d(*rows, ptr);
+                temp = ptr_to_carray(ptr);
+            }
+        }
+    } ZEND_HASH_FOREACH_END();
+    ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(array), row) {
+        ZVAL_DEREF(row);
+        if (Z_TYPE_P(row) == IS_ARRAY) {
+            ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(row), col) {
+                convert_to_double(col);
+                temp.array2d[(j * *rows) + i] = (double)Z_DVAL_P(col);
+                ++j;
+            } ZEND_HASH_FOREACH_END();
+        } else {
+            convert_to_double(row);
+            temp.array1d[i] = (double)Z_DVAL_P(row);
+        }
+        j = 0;
+        ++i;
+    } ZEND_HASH_FOREACH_END();
+}
+
+/**
+ * Get PHP Array number of dimensions
+ *
+ * @author Henrique Borba <henrique.borba.dev@gmail.com>
+ * @param  zval*          Target Array
+ * @param  int*
+ */
+void array_dim(zval * array, int * dim)
+{
+    if(dim == NULL)
+        *dim = 0;
+    zval *entry = NULL;
+    if (Z_TYPE_P(array) == IS_ARRAY) {
+        *dim = *dim + 1;
+        entry = zend_hash_get_current_data(Z_ARRVAL_P(array));
+        array_dim(entry, dim);
+    }
+    return;
+}

--- a/kernel/php_array.h
+++ b/kernel/php_array.h
@@ -21,55 +21,12 @@
   +----------------------------------------------------------------------+
 */
 
-#ifndef PHPSCI_EXT_CARRAY_H
-#define PHPSCI_EXT_CARRAY_H
-#include "../phpsci.h"
+#ifndef PHPSCI_EXT_PHP_ARRAY_H
+#define PHPSCI_EXT_PHP_ARRAY_H
 
-/**
- * PHPSci Shape Structure
- */
-typedef struct Shape {
-    int * shape;
-    int * dim;
-} Shape;
+#include "memory_manager.h"
+#include "php.h"
 
-/**
- * PHPSci internal array structure
- *
- * Currently working with shaped 2D, 1D and 0D.
- */
-typedef struct CArray {
-    // OLD IMPLEMENTATION
-    double *   array2d;
-    double *   array1d;
-    double *   array0d;
-    // NEW IMPLEMENTATION
-    double * array;
-    Shape  * shape;
-} CArray;
-
-/**
- * The only thing between PHP and the extension
- */
-typedef struct MemoryPointer {
-    int uuid;
-    int x;
-    int y;
-} MemoryPointer;
-
-int SHAPE_TO_DIM(Shape * shape);
-int GET_DIM(int x, int y);
-int IS_0D(int x, int y);
-int IS_1D(int x, int y);
-int IS_2D(int x, int y);
-
-void OBJ_TO_PTR(zval * obj, MemoryPointer * ptr);
-void carray_init(int rows, int cols, MemoryPointer * ptr);
-void carray_init1d(int width, MemoryPointer * ptr);
-void carray_init0d(MemoryPointer * ptr);
-void destroy_carray(MemoryPointer * target_ptr);
-
-CArray ptr_to_carray(MemoryPointer * ptr);
-void carray_to_array(CArray carray, zval * rtn_array, int m, int n);
-void double_to_carray(double input, MemoryPointer * rtn_ptr);
-#endif //PHPSCI_EXT_CARRAY_H
+void array_to_carray_ptr(MemoryPointer * ptr, zval * array, int * rows, int * cols);
+void array_dim(zval * array, int * dim);
+#endif //PHPSCI_EXT_PHP_ARRAY_H

--- a/kernel/php_array.h
+++ b/kernel/php_array.h
@@ -28,5 +28,6 @@
 #include "php.h"
 
 void array_to_carray_ptr(MemoryPointer * ptr, zval * array, int * rows, int * cols);
+void array_shape(zval * arr, Shape * shape, int dim, int * iterator);
 void array_dim(zval * array, int * dim);
 #endif //PHPSCI_EXT_PHP_ARRAY_H

--- a/kernel/shape.c
+++ b/kernel/shape.c
@@ -20,33 +20,20 @@
   | Authors: Henrique Borba <henrique.borba.dev@gmail.com>               |
   +----------------------------------------------------------------------+
 */
-
-#ifndef PHPSCI_EXT_PHPSCI_H
-#define PHPSCI_EXT_PHPSCI_H
-
-#define PHP_PHPSCI_EXTNAME "PHPSci"
-#define PHP_PHPSCI_VERSION "0.0.1"
-
-#ifdef ZTS
-#include "TSRM.h"
-#endif
-#include "kernel/exceptions.h"
-#include "kernel/shape.h"
+#include "../phpsci.h"
+#include "shape.h"
 #include "php.h"
 
-
-static zend_class_entry *phpsci_sc_entry;
-static zend_object_handlers phpsci_object_handlers;
-static zend_class_entry *phpsci_exception_sc_entry;
-
-extern zend_module_entry phpsci_module_entry;
-
-#define phpext_phpsci_ptr &phpsci_module_entry
-#define PHPSCI_THROW(message, code) \
-		zend_throw_exception(phpsci_exception_sc_entry, message, (long)code TSRMLS_CC); \
-		return;
-
-
-void RETURN_CARRAY(zval * return_value, int uuid, int x, int y);
-void set_obj_uuid(zval * obj, long uuid);
-#endif //PHPSCI_EXT_PHPSCI_H
+/**
+ * Convert Shape config to PHP Array
+ *
+ * @author Henrique Borba <henrique.borba.dev@gmail.com>
+ */
+void shape_config_to_array(Shape shape, zval * rtn_arr)
+{
+    int iterator_a;
+    array_init(rtn_arr);
+    for( iterator_a = 0; iterator_a < shape.dim; ++iterator_a ) {
+        add_next_index_long(rtn_arr, (long)shape.config[iterator_a]);
+    }
+}

--- a/kernel/shape.h
+++ b/kernel/shape.h
@@ -21,32 +21,18 @@
   +----------------------------------------------------------------------+
 */
 
-#ifndef PHPSCI_EXT_PHPSCI_H
-#define PHPSCI_EXT_PHPSCI_H
+#ifndef PHPSCI_EXT_SHAPE_H
+#define PHPSCI_EXT_SHAPE_H
 
-#define PHP_PHPSCI_EXTNAME "PHPSci"
-#define PHP_PHPSCI_VERSION "0.0.1"
-
-#ifdef ZTS
-#include "TSRM.h"
-#endif
-#include "kernel/exceptions.h"
-#include "kernel/shape.h"
 #include "php.h"
+/**
+ * PHPSci Shape Structure
+ */
+typedef struct Shape {
+    int * config;
+    int  dim;
+} Shape;
 
 
-static zend_class_entry *phpsci_sc_entry;
-static zend_object_handlers phpsci_object_handlers;
-static zend_class_entry *phpsci_exception_sc_entry;
-
-extern zend_module_entry phpsci_module_entry;
-
-#define phpext_phpsci_ptr &phpsci_module_entry
-#define PHPSCI_THROW(message, code) \
-		zend_throw_exception(phpsci_exception_sc_entry, message, (long)code TSRMLS_CC); \
-		return;
-
-
-void RETURN_CARRAY(zval * return_value, int uuid, int x, int y);
-void set_obj_uuid(zval * obj, long uuid);
-#endif //PHPSCI_EXT_PHPSCI_H
+void shape_config_to_array(Shape shape, zval * rtn_arr);
+#endif //PHPSCI_EXT_SHAPE_H

--- a/phpsci.c
+++ b/phpsci.c
@@ -321,8 +321,8 @@ PHP_METHOD(CArray, add)
     MemoryPointer ptr_b;
     OBJ_TO_PTR(a, &ptr_a);
     OBJ_TO_PTR(b, &ptr_b);
-    carray_broadcast_arithmetic(&ptr_a, &ptr_b, &rtn_ptr, &size_x, &size_y, add);
-    RETURN_CARRAY(return_value, rtn_ptr.uuid, size_x, size_y);
+    carray_broadcast_arithmetic(&ptr_a, &ptr_b, &rtn_ptr, add);
+    RETURN_CARRAY(return_value, rtn_ptr.uuid, rtn_ptr.x, rtn_ptr.y);
 }
 PHP_METHOD(CArray, fromDouble)
 {

--- a/phpsci.c
+++ b/phpsci.c
@@ -93,6 +93,9 @@ PHP_METHOD(CArray, __construct)
     zend_update_property_long(phpsci_sc_entry, obj, "x", sizeof("x") - 1, x);
     zend_update_property_long(phpsci_sc_entry, obj, "y", sizeof("y") - 1, y);
 }
+/**
+ * CArray::identity
+ */
 PHP_METHOD(CArray, identity)
 {
     long m;
@@ -105,6 +108,9 @@ PHP_METHOD(CArray, identity)
     identity(&arr, (int)m);
     RETURN_CARRAY(return_value, ptr.uuid, m, m);
 }
+/**
+ * CArray::zeros
+ */
 PHP_METHOD(CArray, zeros)
 {
     long x, y;
@@ -119,6 +125,9 @@ PHP_METHOD(CArray, zeros)
     zeros(&arr, (int)x, (int)y);
     RETURN_CARRAY(return_value, ptr.uuid, x, y);
 }
+/**
+ * CArray::standard_normal
+ */
 PHP_METHOD(CArray, standard_normal)
 {
     long x, y, seed;
@@ -145,6 +154,9 @@ PHP_METHOD(CArray, standard_normal)
         return;
     }
 }
+/**
+ * CArray::fromArray
+ */
 PHP_METHOD(CArray, fromArray)
 {
     zval * array;
@@ -158,6 +170,9 @@ PHP_METHOD(CArray, fromArray)
     array_to_carray_ptr(&ptr, array, &a_rows, &a_cols);
     RETURN_CARRAY(return_value, ptr.uuid, a_rows, a_cols);
 }
+/**
+ * Destructor
+ */
 PHP_METHOD(CArray, __destruct)
 {
     zval * obj = getThis();
@@ -165,6 +180,9 @@ PHP_METHOD(CArray, __destruct)
     OBJ_TO_PTR(obj, &target_ptr);
     //destroy_carray(&target_ptr);
 }
+/**
+ * CArray::transpose
+ */
 PHP_METHOD(CArray, transpose)
 {
     zval * obj;
@@ -177,6 +195,9 @@ PHP_METHOD(CArray, transpose)
     transpose(&rtn, &ptr, (int)ptr.x, (int)ptr.y);
     RETURN_CARRAY(return_value, rtn.uuid, ptr.y, ptr.x);
 }
+/**
+ * CArray::print_r
+ */
 PHP_METHOD(CArray, print_r) {
     zval * a;
     ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -186,6 +207,9 @@ PHP_METHOD(CArray, print_r) {
     OBJ_TO_PTR(a, &ptr);
     print_carray(&ptr, ptr.x, ptr.y);
 }
+/**
+ * CArray::toArray
+ */
 PHP_METHOD(CArray, toArray)
 {
     int rows, cols;
@@ -198,6 +222,9 @@ PHP_METHOD(CArray, toArray)
     CArray arr = ptr_to_carray(&ptr);
     carray_to_array(arr, return_value, ptr.x, ptr.y);
 }
+/**
+ * CArray::linspace
+ */
 PHP_METHOD(CArray, linspace)
 {
     double start, stop;
@@ -211,6 +238,9 @@ PHP_METHOD(CArray, linspace)
     linspace(&ptr, (double)start, (double)stop, (double)num);
     RETURN_CARRAY(return_value, ptr.uuid, num, 0);
 }
+/**
+ * CArray::logspace
+ */
 PHP_METHOD(CArray, logspace)
 {
     double start, stop, base;
@@ -225,6 +255,9 @@ PHP_METHOD(CArray, logspace)
     logspace(&ptr, (double)start, (double)stop, num, (double)base);
     RETURN_CARRAY(return_value, ptr.uuid, num, 0);
 }
+/**
+ * CArray::toDouble
+ */
 PHP_METHOD(CArray, toDouble)
 {
     long uuid;
@@ -237,6 +270,9 @@ PHP_METHOD(CArray, toDouble)
     CArray arr = ptr_to_carray(&ptr);
     ZVAL_DOUBLE(return_value, (double)arr.array0d[0]);
 }
+/**
+ * CArray::sum
+ */
 PHP_METHOD(CArray, sum)
 {
     long axis;
@@ -260,6 +296,9 @@ PHP_METHOD(CArray, sum)
     }
     RETURN_CARRAY(return_value, target_ptr.uuid, size_x, size_y);
 }
+/**
+ * CArray::inner
+ */
 PHP_METHOD(CArray, inner)
 {
     long a_uuid, a_x, a_y, b_uuid, b_x, b_y;
@@ -275,6 +314,9 @@ PHP_METHOD(CArray, inner)
     inner(&rtn_x, &rtn_y, &rtn_ptr, (int)a_ptr.x, (int)a_ptr.y, &a_ptr, (int)b_ptr.x, (int)b_ptr.y, &b_ptr);
     RETURN_CARRAY(return_value, rtn_ptr.uuid, rtn_x, rtn_y);
 }
+/**
+ * CArray::matmul
+ */
 PHP_METHOD(CArray, matmul)
 {
     MemoryPointer a_ptr, b_ptr, rtn_ptr;
@@ -295,6 +337,9 @@ PHP_METHOD(CArray, matmul)
         return;
     }
 }
+/**
+ * CArray::arange
+ */
 PHP_METHOD(CArray, arange)
 {
     double start, stop, step;
@@ -308,6 +353,9 @@ PHP_METHOD(CArray, arange)
     arange(&ptr, start, stop, step, &width);
     RETURN_CARRAY(return_value, ptr.uuid, width, 0);
 }
+/**
+ * CArray::add
+ */
 PHP_METHOD(CArray, add)
 {
     zval * a, * b;
@@ -324,6 +372,9 @@ PHP_METHOD(CArray, add)
     carray_broadcast_arithmetic(&ptr_a, &ptr_b, &rtn_ptr, add);
     RETURN_CARRAY(return_value, rtn_ptr.uuid, rtn_ptr.x, rtn_ptr.y);
 }
+/**
+ * CArray::fromDouble
+ */
 PHP_METHOD(CArray, fromDouble)
 {
     double input;
@@ -334,6 +385,9 @@ PHP_METHOD(CArray, fromDouble)
     double_to_carray(input, &ptr);
     RETURN_CARRAY(return_value, ptr.uuid, 0, 0);
 }
+/**
+ * CArray::inv
+ */
 PHP_METHOD(CArray, inv)
 {
     zval * a;

--- a/phpsci.c
+++ b/phpsci.c
@@ -36,6 +36,7 @@
 #include "kernel/carray_printer.h"
 #include "kernel/memory_manager.h"
 #include "kernel/php_array.h"
+#include "kernel/shape.h"
 #include "kernel/exceptions.h"
 #include "Zend/zend_exceptions.h"
 #include "php.h"
@@ -159,16 +160,21 @@ PHP_METHOD(CArray, standard_normal)
  */
 PHP_METHOD(CArray, fromArray)
 {
-    zval * array;
+    zval * array, rtn_shape;
     int a_rows, a_cols;
 
     ZEND_PARSE_PARAMETERS_START(1, -1)
         Z_PARAM_ARRAY(array)
     ZEND_PARSE_PARAMETERS_END();
+
     MemoryPointer ptr;
     ptr.uuid = UNINITIALIZED;
     array_to_carray_ptr(&ptr, array, &a_rows, &a_cols);
+    CArray * rtn_arr = ptr_to_carray_ref(&ptr);
     RETURN_CARRAY(return_value, ptr.uuid, a_rows, a_cols);
+    shape_config_to_array(rtn_arr->array_shape, &rtn_shape);
+    zend_update_property_long(phpsci_sc_entry, return_value, "dim", sizeof("dim") - 1, (long)rtn_arr->array_shape.dim);
+    zend_update_property(phpsci_sc_entry, return_value, "shape", sizeof("shape") - 1, &rtn_shape);
 }
 /**
  * Destructor


### PR DESCRIPTION
New CArray Architecture implements the Shape structure, N-Dimensional arrays broadcast for arithmetic operations, N-Dimensional arrays validation for arithmetic operations.

```C
/**
 * PHPSci Shape Structure
 */
typedef struct Shape {
    int * shape;
    int * dim;
} Shape;

/**
 * PHPSci internal array structure
 *
 * Currently working with shaped 2D, 1D and 0D.
 */
typedef struct CArray {
    // OLD IMPLEMENTATION
    double *   array2d;
    double *   array1d;
    double *   array0d;
    // NEW IMPLEMENTATION
    double *   array;
    Shape  *   array_shape;
} CArray;
```

`add` static method shows the partial implementation:
```C
PHP_METHOD(CArray, add)
{
    zval * a, * b;
    int  size_x, size_y;
    ZEND_PARSE_PARAMETERS_START(2, 2)
        Z_PARAM_OBJECT(a)
        Z_PARAM_OBJECT(b)
    ZEND_PARSE_PARAMETERS_END();
    MemoryPointer rtn_ptr;
    MemoryPointer ptr_a;
    MemoryPointer ptr_b;
    OBJ_TO_PTR(a, &ptr_a);
    OBJ_TO_PTR(b, &ptr_b);
    carray_broadcast_arithmetic(&ptr_a, &ptr_b, &rtn_ptr, add);
    RETURN_CARRAY(return_value, rtn_ptr.uuid, rtn_ptr.x, rtn_ptr.y);
}
```

- Created `php_array.c` to handle PHP array data and functions.
- Partially implemented new CArray pointer.
- Added array_dim function for PHP Arrays dimensions count.
- Added exception class `CArrayBroadcastException`
- PHP Arrays related functions were moved to `php_array.c`
- CArray Struct shape property changed to `array_shape`
- Implemented `carray_broadcast_arithmetic()` to handle rules and broadcasting.
- Partially implemented `carray_broadcast_arithmetic()` within `add` method.
- Dummy static method added to CArray class, it will be removed before release.